### PR TITLE
Downgrade Jquery

### DIFF
--- a/dickpunch.user.js
+++ b/dickpunch.user.js
@@ -4,7 +4,7 @@
 // @version      1.0.1.1
 // @description  A literal dick waving contest
 // @author       You
-// @require      https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js
+// @require      https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js
 // @match        *://facepunch.com/*
 // @grant        none
 // @downloadURL  https://raw.githubusercontent.com/meharryp/dickpunch/master/dickpunch.user.js


### PR DESCRIPTION
Instead of grabbing and embedding the new version, use the version which is already loaded (and/or probably browser-cached) from Facepunch's script tags